### PR TITLE
small fix

### DIFF
--- a/server-rbpi3/update.sh
+++ b/server-rbpi3/update.sh
@@ -102,7 +102,7 @@ if [ -e /var/www/html_old_"$NOW"/src/SuplaBundle/Command/SimulateEventsCommand.p
 fi
 
 # Cleaning unnecessary post-installation files
-rm -fr var/cache/prod
+rm -fr var/cache/*
 php bin/console cache:warmup
 rm -fr $TEMPDIR
 

--- a/server-rbpi3/update.sh
+++ b/server-rbpi3/update.sh
@@ -104,6 +104,7 @@ fi
 # Cleaning unnecessary post-installation files
 rm -fr var/cache/*
 php bin/console cache:warmup
+chown -R www-data:www-data var/cache
 rm -fr $TEMPDIR
 
 # Restart and launch of the Supla


### PR DESCRIPTION
For installations without a container, there was this error:
chown: change of owner "/var/www/html/var/cache/prod/ContainerThbgccn/getControllingTheRoletteShutterClosingTimerService.phpyHnZVc": There is no such file or directory
chown: change of owner "/var/www/html/var/cache/prod/ContainerThbgccn/getImpulseCounterImpulsesPerUnitService.phpPO1HaW": There is no such file or directory